### PR TITLE
Add X-Purism-FormFactor option to .desktop file

### DIFF
--- a/data/browser/io.github.remindersdevs.Reminders.desktop.in.in
+++ b/data/browser/io.github.remindersdevs.Reminders.desktop.in.in
@@ -12,3 +12,5 @@ Categories=GNOME;GTK;Office;ProjectManagement;
 Keywords=Todo;Productivity;Task;Planning;Planner;Time;Management;Reminder;Remembrance;Reminders;
 MimeType=text/calendar;
 X-GNOME-UsesNotifications=true
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
This will cause the app to show by default in the Phosh launcher on mobile linux devices such as the Pinephone and Librem5

https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps